### PR TITLE
Fix issue with century ranges

### DIFF
--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -107,4 +107,11 @@
     XCTAssertNil([ssn dateOfBirthString]);
 }
 
+- (void)testSSNInTwentyFirstCentury {
+    HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01030099911"];
+
+    XCTAssertTrue(ssn.isValid);
+    XCTAssertEqualObjects(ssn.age, @15);
+}
+
 @end

--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -107,6 +107,11 @@
     XCTAssertNil([ssn dateOfBirthString]);
 }
 
+- (void)testSSNTwentiethCentury {
+    HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01010135369"];
+    XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01011901");
+}
+
 - (void)testSSNInTwentyFirstCenturyAtEndOfRange {
     HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01030099911"];
 

--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -107,11 +107,11 @@
     XCTAssertNil([ssn dateOfBirthString]);
 }
 
-- (void)testSSNInTwentyFirstCentury {
+- (void)testSSNInTwentyFirstCenturyAtEndOfRange {
     HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01030099911"];
 
     XCTAssertTrue(ssn.isValid);
-    XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01302000");
+    XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01032000");
 }
 
 @end

--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -111,7 +111,7 @@
     HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01030099911"];
 
     XCTAssertTrue(ssn.isValid);
-    XCTAssertEqualObjects(ssn.age, @15);
+    XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01302000");
 }
 
 @end

--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -119,4 +119,9 @@
     XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01032000");
 }
 
+- (void)testSSNInTwentyFirstCenturyAlternateRange {
+    HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01014599939"];
+    XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01011945");
+}
+
 @end

--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -112,7 +112,7 @@
     XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01011901");
 }
 
-- (void)testSSNInTwentyFirstCenturyAtEndOfRange {
+- (void)testSSNInTwentyFirstCentury {
     HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01030099911"];
 
     XCTAssertTrue(ssn.isValid);

--- a/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
+++ b/HYPNorwegianSSNTests/HYPNorwegianSSNTests.m
@@ -107,6 +107,11 @@
     XCTAssertNil([ssn dateOfBirthString]);
 }
 
+- (void)testSSNNineteenthCenturyRange {
+    HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01015574883"];
+    XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01011855");
+}
+
 - (void)testSSNTwentiethCentury {
     HYPNorwegianSSN *ssn = [[HYPNorwegianSSN alloc] initWithString:@"01010135369"];
     XCTAssertEqualObjects(ssn.dateOfBirthStringWithCentury, @"01011901");

--- a/Source/HYPNorwegianSSN.m
+++ b/Source/HYPNorwegianSSN.m
@@ -2,8 +2,8 @@
 
 NSRange HYPTwentiethCenturyRange = {0, 500};
 NSRange HYPNineteenthCenturyRange = {500, 749-501};
-NSRange HYPTwentiethCenturyAlternateRange = {900, 999-901};
 NSRange HYPTwentyFirstCenturyRange = {500, 999-499};
+NSRange HYPTwentiethCenturyAlternateRange = {900, 100};
 
 NSUInteger HYPValidSSNLength = 11;
 NSUInteger HYPValidSSNControlNumber = 11;

--- a/Source/HYPNorwegianSSN.m
+++ b/Source/HYPNorwegianSSN.m
@@ -1,7 +1,7 @@
 #import "HYPNorwegianSSN.h"
 
 NSRange HYPTwentiethCenturyRange = {0, 500};
-NSRange HYPNineteenthCenturyRange = {500, 749-501};
+NSRange HYPNineteenthCenturyRange = {500, 749-499};
 NSRange HYPTwentyFirstCenturyRange = {500, 999-499};
 NSRange HYPTwentiethCenturyAlternateRange = {900, 100};
 

--- a/Source/HYPNorwegianSSN.m
+++ b/Source/HYPNorwegianSSN.m
@@ -2,8 +2,8 @@
 
 NSRange HYPTwentiethCenturyRange = {0, 500};
 NSRange HYPNineteenthCenturyRange = {500, 749-501};
-NSRange HYPTwentyFirstCenturyRange = {500, 999-501};
 NSRange HYPTwentiethCenturyAlternateRange = {900, 999-901};
+NSRange HYPTwentyFirstCenturyRange = {500, 999-499};
 
 NSUInteger HYPValidSSNLength = 11;
 NSUInteger HYPValidSSNControlNumber = 11;


### PR DESCRIPTION
The range did not include 999 and so on, so edge cases occurred when stuff was at the end of a range.